### PR TITLE
Re-added the read write access for the share folder.

### DIFF
--- a/qbittorrent/config.json
+++ b/qbittorrent/config.json
@@ -15,6 +15,7 @@
     "map":[
         "media:rw",
         "config:rw",
+        "share:rw",
         "ssl"
     ],
     "boot": "auto",


### PR DESCRIPTION
As the default save folder by qBittorrent is the share folder I suggest to add the read/write access for the share folder back in.